### PR TITLE
Fix typo in 4. Peppol Identifiers of Debit Note (BIS)

### DIFF
--- a/guide/bis-debnt/shared/profiles/01.adoc
+++ b/guide/bis-debnt/shared/profiles/01.adoc
@@ -1,6 +1,6 @@
 
 [[prof-01]]
-= Summarised invoice messages
+= Debit Note messages
 
 In the table below you will find the values to be used as the specification identifier (IBT-24) and the business process type (IBT-23) for this profile
 


### PR DESCRIPTION
Should "4.2. Summarised invoice messages" be "4.2. Debit Note messages" ?